### PR TITLE
FFS-2190: Oppgrader HMSREG-gateway til web-instance-gateway 3.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-3")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-1")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-2")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-2")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-3")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-instance-gateway:2.4.0")
+    implementation("no.novari:flyt-web-instance-gateway:3.0.0-rc-1")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 


### PR DESCRIPTION
## Summary

Implements [FFS-2190](https://novari-iks.atlassian.net/browse/FFS-2190).

- Oppgraderer til `flyt-web-instance-gateway:3.0.0`.
- Arver web-resource-server 4.0.0 gjennom web-instance-gateway uten direkte avhengighet.

[FFS-2190]: https://novari-iks.atlassian.net/browse/FFS-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ