### PR TITLE
FFS-2233: Rull ut OpenTelemetry-sporing (HTTP + Kafka)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0")
+    implementation("no.novari:flyt-web-instance-gateway:3.1.0-rc-3")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/afk-no"
     target:

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/agderfk-no"
     target:

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/agderfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/bfk-no"
     target:

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/ffk-no"
     target:

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/ffk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/fintlabs-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/innlandetfylke-no"
     target:

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/innlandetfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/mrfylke-no"
     target:

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/nfk-no"
     target:

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/ofk-no"
     target:

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/rogfk-no"
     target:

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/rogfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/telemarkfylke-no"
     target:

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/telemarkfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/tromsfylke-no"
       - op: add

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/tromsfylke-no"
       - op: add
@@ -48,6 +53,11 @@ patches:
         value:
           name: "logging.level.no.novari.flyt.gateway.webinstance"
           value: "DEBUG"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/trondelagfylke-no"
     target:

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/trondelagfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/vestfoldfylke-no"
     target:

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/vestfoldfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/vlfk-no"
     target:

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -41,8 +41,18 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/vlfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-hmsreg-gateway

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 spring:
   kafka:
     consumer:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,8 @@ server:
   max-http-request-header-size: 40KB
 
 spring:
+  application:
+    name: ${fint.application-id}
   servlet:
     multipart:
       max-file-size: 500MB

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Sammendrag

Ruller ut OpenTelemetry-sporing for HTTP og Kafka til `fint-flyt-hmsreg-gateway`, etter samme mønster som allerede rullet ut til `fint-flyt-egrunnerverv-gateway`, `fint-flyt-file-service`, `fint-flyt-authorization-service` og `fint-flyt-instance-service` i epicen [FFS-2196](https://novari-iks.atlassian.net/browse/FFS-2196).

- Bumper `no.novari:flyt-web-instance-gateway` fra `3.0.0` til `3.1.0-rc-3` (drar med `flyt-web-resource-server:4.1.0-rc-2` og `flyt-kafka:7.3.0-rc-2` transitivt, ingen eksplisitt pinning nødvendig)
- Legger til `no.novari:telemetry-starter:0.0.4`, inkludert fiksen fra [fint-telemetry-starter#4](https://github.com/FINTLabs/fint-telemetry-starter/pull/4) (actuator-ekskludering med `server.servlet.context-path` satt)
- Setter `spring.application.name: ${fint.application-id}` i `application.yaml` (kreves av telemetry-starter, manglet fra før)
- Slår på `novari.kafka.tracing.enabled: true` i `application-flyt-kafka.yaml`
- Legger `novari.telemetry.org-id` som miljøvariabel på alle 27 kustomize-overlays, med samme verdi som eksisterende `orgId`/`fintlabs.no/org-id`
- Legger `OTEL_EXPORTER_OTLP_ENDPOINT` (uten `/v1/traces`) på de 13 beta-overlayene, inntil FLAIS får plattformstøtte for eksport-endepunktet i produksjon

Kustomize-overlays i dette repoet er håndredigerte (ingen genereringsscript), så alle 27 `kustomization.yaml`-filer er endret direkte. Verifisert med `kustomize build` på samtlige.

`./gradlew check` er grønt.

[FFS-2196]: https://novari-iks.atlassian.net/browse/FFS-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ